### PR TITLE
Fixed for current version of Bob's

### DIFF
--- a/data-updates.lua
+++ b/data-updates.lua
@@ -1,14 +1,14 @@
--- Force wooden board alternatives to be created in assemblers
+-- Force Wooden Boards made from Synthetic to be made in Electronics machine, Force Cellulose wood to be created in assemblers
 
 local function force_assembler(recipe)
-	if data.raw.recipe[recipe] then
-		data.raw.recipe[recipe].category = "advanced-crafting"
-	end
+    if data.raw.recipe[recipe] then
+        data.raw.recipe[recipe].category = "electronics-machine"
+    end
 end
 
 -- Bob's Plates
 -- Synthetic wood from oil
-force_assembler("synthetic-wood")
+force_assembler("wooden-board-synthetic")
 
 -- Angel's Bioprocessing
 force_assembler("wood-from-cellulose-resin")

--- a/info.json
+++ b/info.json
@@ -1,6 +1,6 @@
 {
   "name": "fix_recursivehandcrafting",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "factorio_version": "0.14",
   "title": "Recursive Handcrafting Fix",
   "author": "Xuerian",


### PR DESCRIPTION
Previous addon amended wooden board recipe to prevent hand crafting. New Bob's doesn't that to begin with, so have instead modified the basic wooden circuit board that uses the synthetic wood to be assembler only. Have tested on with latest Factorio and latest Bob's.

Also, updated version number minor.

tl;dr:
Changed synthetic circuit board to assembler only
Updated version number